### PR TITLE
Add injuries endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -65,6 +65,14 @@ class App < Sinatra::Base
     service.my_player_projections(players, week)
   end
 
+  get '/injuries' do
+    return invalid_key_message unless valid_open_key?(params[:key])
+
+    service = FFNService.new('injuries')
+    content_type :json
+    service.current_injuries
+  end
+
   get '/players' do
     return invalid_key_message unless valid_admin_key?(params[:key])
 

--- a/services/ffn_service.rb
+++ b/services/ffn_service.rb
@@ -56,6 +56,16 @@ class FFNService
     calculate_projections(most_recent, current_week)
   end
 
+  def current_injuries
+    response = fetch('')
+    data = parse_json(response.body)
+    data[:Injuries].map { |k,v| v }
+                   .flatten
+                   .reject { |plyr| plyr[:playerId] == '0' }
+                   .sort_by { |plyr| plyr[:playerId] }
+                   .to_json
+  end
+
   def calculate_projections(data, week)
     data.map do |proj|
       { 'week' => week.to_i, 'ffn_id' => proj.playerId, 'projection' => proj.calculate }

--- a/spec/endpoints/injuries_spec.rb
+++ b/spec/endpoints/injuries_spec.rb
@@ -1,0 +1,31 @@
+require 'acceptance_helper'
+
+describe '/injuries', type: :feature do
+  it 'returns players who are currently injured, including the status' do
+    WebMock.allow_net_connect!
+
+    key = create_admin_key
+
+    get "/injuries?key=#{key}"
+
+    expect(last_response).to be_successful
+
+    expected = {
+      "week" => "8",
+      "playerId" => "102",
+      "playerName" => "Drew Stanton",
+      "team" => "CLE",
+      "position" => "QB",
+      "injury" => "Knee",
+      "practiceStatus" => "",
+      "gameStatus" => "Ir. Injured Reserve",
+      "notes" => "",
+      "lastUpdate" => "2019-10-28",
+      "practiceStatusId" => ""
+    }
+
+    data = JSON.parse(last_response.body)
+
+    expect(data.first).to eq(expected)
+  end
+end


### PR DESCRIPTION
### Endpoint `/injuries`
-Gets data from fantasyfootballnerd api.
- Eliminates players if they are not fantasy players (playerId == '0')
- Sorts by playerId (to help the rake task in front end)
