### PR TITLE
Add /all_player_projections endpoint

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -65,6 +65,15 @@ class App < Sinatra::Base
     service.my_player_projections(players, week)
   end
 
+  get '/all_player_projections/:id' do
+    return invalid_key_message unless valid_admin_key?(params[:key])
+    
+    id = params[:id].to_i
+    service = FFNService.new
+    content_type :json
+    service.all_player_projections(id)
+  end
+
   get '/injuries' do
     return invalid_key_message unless valid_open_key?(params[:key])
 

--- a/services/ffn_service.rb
+++ b/services/ffn_service.rb
@@ -61,7 +61,12 @@ class FFNService
   def my_player_projections(players, week)
     week = week || Projection.maximum(:week)
     my_projections = Projection.my_projections(players, week)
-    calculate_projections(my_projections, week)
+    calculate_projections(my_projections)
+  end
+
+  def all_player_projections(id)
+    data = Projection.where(playerId: id)
+    calculate_projections(data)
   end
 
   def current_projections(max_week)
@@ -71,7 +76,7 @@ class FFNService
     current_week = Projection.maximum(:week)
     most_recent = Projection.where(week: current_week)
                             .order(:playerId)
-    calculate_projections(most_recent, current_week)
+    calculate_projections(most_recent)
   end
 
   def current_injuries(week = nil)
@@ -85,9 +90,9 @@ class FFNService
                    .to_json
   end
 
-  def calculate_projections(data, week)
+  def calculate_projections(data)
     data.map do |proj|
-      { 'week' => week.to_i, 'ffn_id' => proj.playerId, 'projection' => proj.calculate }
+       { 'week' => proj.week, 'ffn_id' => proj.playerId, 'projection' => proj.calculate }
     end.to_json
   end
 

--- a/spec/endpoints/all_player_projections_spec.rb
+++ b/spec/endpoints/all_player_projections_spec.rb
@@ -1,0 +1,31 @@
+require 'acceptance_helper'
+
+describe '/all_player_projections/:player_id' do
+  before :each do
+    @key = create_admin_key
+
+    stub_projections('QB', 1)
+    stub_projections('QB', 2)
+    stub_projections('QB', 3)
+
+    get "/projections/update/QB/1?key=#{@key}"
+    get "/projections/update/QB/2?key=#{@key}"
+    get "/projections/update/QB/3?key=#{@key}"
+  end
+
+  scenario 'returns all projections for a player' do
+    get "/all_player_projections/13?key=#{@key}"
+
+    expect(last_response).to be_successful
+
+    result = [
+      { 'week' => 1, 'ffn_id' => 13, 'projection' => 18.67 },
+      { 'week' => 2, 'ffn_id' => 13, 'projection' => 21.05 },
+      { 'week' => 3, 'ffn_id' => 13, 'projection' => 20.24 }
+    ]
+
+    data = JSON.parse(last_response.body)
+
+    expect(data).to eq(result)
+  end
+end


### PR DESCRIPTION
### /all_player_projections/:id?key={key}
- Returns all projections for a player with given player id (ffn_id)
- This can be used on the player bio page to show how their projected stats have changed over the season